### PR TITLE
Hack to make package_item snippet work even if provided dict instead …

### DIFF
--- a/ckanext/pigma_theme/plugin.py
+++ b/ckanext/pigma_theme/plugin.py
@@ -7,9 +7,18 @@ import ckan.plugins as plugins
 import ckan.plugins.toolkit as toolkit
 from ckan.plugins.toolkit import _
 from ckanext.spatial.interfaces import ISpatialHarvester
+from ckan.lib.helpers import dict_list_reduce
 
 import logging
 log = logging.getLogger(__name__)
+
+
+# Template helper functions
+def dict_list_or_dict_reduce(list_, key, unique=True):
+    """Hack to make helpers.dict_list_reduce work also if provided a dict of dicts instead of a list of dicts"""
+    if isinstance(list_, dict):
+        list_ = list_.values()
+    return dict_list_reduce(list_, key, unique)
 
 
 class Pigma_ThemePlugin(plugins.SingletonPlugin):
@@ -18,6 +27,7 @@ class Pigma_ThemePlugin(plugins.SingletonPlugin):
     plugins.implements(plugins.IPackageController, inherit=True)
     plugins.implements(plugins.ITranslation)
     plugins.implements(ISpatialHarvester, inherit=True)
+    plugins.implements(plugins.ITemplateHelpers)
 
     # IConfigurer
     def update_config(self, config_):
@@ -71,6 +81,18 @@ class Pigma_ThemePlugin(plugins.SingletonPlugin):
         package_dict['groups'] = list(groups)
 
         return package_dict
+
+    #ITemplateHelper
+    def get_helpers(self):
+        '''Register the most_popular_groups() function above as a template
+        helper function.
+
+        '''
+        # Template helper function names should begin with the name of the
+        # extension they belong to, to avoid clashing with functions from
+        # other extensions.
+        return {'dict_list_or_dict_reduce': dict_list_or_dict_reduce}
+
 
 mapping = {
         "administration": (

--- a/ckanext/pigma_theme/templates/snippets/package_item.html
+++ b/ckanext/pigma_theme/templates/snippets/package_item.html
@@ -77,7 +77,7 @@ Example:
         {% if package.resources and not hide_resources %}
           {% block resources_outer %}
             <ul class="dataset-resources unstyled">
-                {% for resource in h.dict_list_reduce(package.resources.values(), 'format') %}
+                {% for resource in h.dict_list_or_dict_reduce(package.resources, 'format') %}
                 <li class="dataset-format">
                   <a href="{{ h.url_for(controller='package', action='read', id=package.name) }}" class="label" data-format="{{ resource.lower() }}">{{ resource }}</a>
                 </li>


### PR DESCRIPTION
…of list

In the main page, the bottom snippet listing packages by pigma groups get, for some
reason, a dict of datasets instead of a list of datasets, hence the need to make
helpers.dict_list_reduce work also if provided a dict of dicts instead of a list
of dicts

This is only a hack. Probably it would be better to find out how we happen to get a dict instead of a list, but I can't find out why or where it happens...