### PR TITLE
Backport from pigma

### DIFF
--- a/ckanext/theme/harvest_helpers.py
+++ b/ckanext/theme/harvest_helpers.py
@@ -262,13 +262,22 @@ def _gn_csw_build_inspire_link(harvester_source, iso_values):
             url = u"{}/catalog.search#/metadata/{}".format(base_url.group(1), iso_values.get('guid'))
         #TODO: check if the url is valid and if not try other ways, like for instance the unique-resource-identifier value
         # or try other patterns matching catalogs other than geonetwork
-        if urllib.urlopen(url).getcode() == 200:
+        try:
             return url
+            if urllib.urlopen(url).getcode() == 200:
+                return url
+        except:
+            pass
 
         # 2. Return the value of unique-resource-identifier if valid
-        url = iso_values.get('unique-resource-identifier')
-        if urllib.urlopen(url).getcode() == 200:
-            return url
+        try:
+            if urllib.urlopen(url).getcode() == 200:
+                url = iso_values.get('unique-resource-identifier')
+                return url
+                if urllib.urlopen(url).getcode() == 200:
+                    return url
+        except:
+            pass
 
     # else...
     return ''
@@ -466,7 +475,7 @@ def fix_harvest_scheme_fields(package_dict, data_dict):
     for resource in package_dict['resources']:
         _fix_resource(resource)
 
-    # Compute values not present as-is in geonetwork
+    # Compute values not present as-is in csw
     package_dict['hyperlink'] = _gn_csw_build_inspire_link(data_dict['harvest_object'].source, iso_values)
     package_dict['topic-categories'] = ', '.join(iso_values.get('topic-category'))
     # set a consistent point of contact (name & email match a same entity instead of random-ish)
@@ -503,9 +512,20 @@ def fix_harvest_scheme_fields(package_dict, data_dict):
     extras_keys_dict['metadata_created'] = {'key': 'metadata_created', 'value': _get_value(extras_keys_dict, 'metadata-date', '')}
     extras_keys_dict['metadata_modified'] = {'key': 'metadata_modified', 'value': _get_value(extras_keys_dict, 'metadata-date', '')}
 
+    # catalog-specific work
+    try:
+        fetchGeonetworkExtras(package_dict, data_dict, iso_values)
+    except:
+        pass # probably not a geonetwork catalog then
+
     # Finally, drop extras as scheming doesn't allow extras FALSE ! No need, just remove the scheming synonyms from extras
     # extras_keys_dict.pop('extras', None)
     package_dict['extras'] = extras_keys_dict.values()
+
+
+def fetchGeonetworkExtras(package_dict, data_dict, iso_values):
+    package_dict['inspire_url'] = _gn_csw_build_inspire_link(data_dict['harvest_object'].source, iso_values)
+
 
 def sanitizeKeyword(s, strict=True):
     """

--- a/ckanext/theme/harvest_helpers.py
+++ b/ckanext/theme/harvest_helpers.py
@@ -461,7 +461,7 @@ def fix_harvest_scheme_fields(package_dict, data_dict):
         pass
     if harvest_config.get('compliant_tags', True) and not harvest_config.get('clean_tags', False):
         for tag in package_dict['tags']:
-            tag['name'] = sanitizeKeyword(tag['name'], strict=False)
+            tag['name'] = sanitize_keyword(tag['name'], strict=False)
 
     try:
         # try to get the GN uuid as id for the dataset
@@ -514,7 +514,7 @@ def fix_harvest_scheme_fields(package_dict, data_dict):
 
     # catalog-specific work
     try:
-        fetchGeonetworkExtras(package_dict, data_dict, iso_values)
+        fetch_geonetwork_extras(package_dict, data_dict, iso_values)
     except:
         pass # probably not a geonetwork catalog then
 
@@ -523,11 +523,11 @@ def fix_harvest_scheme_fields(package_dict, data_dict):
     package_dict['extras'] = extras_keys_dict.values()
 
 
-def fetchGeonetworkExtras(package_dict, data_dict, iso_values):
+def fetch_geonetwork_extras(package_dict, data_dict, iso_values):
     package_dict['inspire_url'] = _gn_csw_build_inspire_link(data_dict['harvest_object'].source, iso_values)
 
 
-def sanitizeKeyword(s, strict=True):
+def sanitize_keyword(s, strict=True):
     """
     Make string compatible for usage as CKAN keywords:
     keywords rules are not very clear. It seems at first it did not support anything out of lowercased characters and _-

--- a/ckanext/theme/plugin.py
+++ b/ckanext/theme/plugin.py
@@ -37,7 +37,7 @@ class ThemePlugin(plugins.SingletonPlugin):
         map.connect('ckanext_theme_organizations_index', '/organization?q=&sort=package_count+desc', action='index')
         return map
 
-    def after_map(selfself, map):
+    def after_map(self, map):
         return map
 
     # Iconfigurable

--- a/ckanext/theme/templates/scheming/form_snippets/textarea_hidden.html
+++ b/ckanext/theme/templates/scheming/form_snippets/textarea_hidden.html
@@ -8,7 +8,7 @@
     placeholder=h.scheming_language_text(field.form_placeholder),
     value=data[field.field_name],
     error=errors[field.field_name],
-    attrs=dict({"class": "form-control"}, **(field.get('form_attrs', {}))),
+    attrs=dict({"disabled":true, "class": "form-control"}, **(field.get('form_attrs', {}))),
     is_required=h.scheming_field_required(field),
     )
 %}


### PR DESCRIPTION
Backports from pigma, from before theme became a submodule again.

Does not backport the changes on Groups & Organization UI changes (see GSKAN 273). For those commits, we need to check if it is relevant for HDF