### PR TITLE
Make pigma customization responsive.

### DIFF
--- a/ckanext/theme/fanstatic/base_theme.css
+++ b/ckanext/theme/fanstatic/base_theme.css
@@ -1,0 +1,162 @@
+.search-form {
+  margin-bottom: 20px;
+  padding-bottom: 25px;
+  border-bottom: 1px dotted #dddddd;
+  z-index: auto;
+}
+/* Dataset */
+.dataset-item {
+  padding: 5em 0 0.5em 0 !important;
+  border-bottom: none;
+  border-left: 2px solid #0072bc;
+  margin-bottom: 35px;
+  border-radius: 0;
+  position: relative;
+  background: white;
+}
+.dataset-item-content.image {
+  max-height: 100px;
+  display: block;
+}
+.dataset-item-content.text {
+    width: calc(100% - 145px);
+    padding-left: 20px;
+}
+.dataset-item-content .dataset-heading {
+  position: absolute;
+  top: .5em;
+  text-overflow:ellipsis;
+  overflow-x:hidden;
+  white-space:nowrap;
+  width: calc(100% - 32px);
+}
+/*** Image dataset  ***/
+.dataset-item-content.image {
+    height: 140px;
+    width: 140px;
+    text-align: center;
+    white-space: nowrap;
+    margin-left: auto;
+    margin-right: auto;
+}
+.dataset-item-content.image:before {
+    content: "";
+    display: inline-block;
+    height: 100%;
+    vertical-align: middle;
+}
+.dataset-item-content.image img.dataset-thematic {
+    margin-top: 25%;
+}
+.dataset-item-content.image img.dataset-thumbnail {
+    vertical-align: middle;
+    max-height: 100%;
+    max-width: 100%;
+}
+
+.homepage .media-grid {
+  padding: 5px 0 0 5px;
+  display: flex;
+  flex-wrap: wrap;
+}
+.homepage .media-item {
+  max-width: none;
+  margin: 0 5px 5px 0px;
+  flex: 1 0 calc(33.3% - 10px);
+}
+.media-heading {
+  font-size: 16px;
+  letter-spacing: -1px;
+  margin: 0 -5px;
+}
+
+@media (max-width: 768px) {
+  /* Home page */
+  .masthead .container nav .nav-pills {
+    display: flex;
+    flex-wrap: wrap;
+    margin: 0 -1px 10px -1px;
+  }
+  .masthead nav ul li {
+    flex: 1 1 50%;
+    margin: 0;
+  }
+  .masthead nav ul li a {
+    border: 1px solid #ddd;
+    margin: 1px;
+  }
+  .homepage .module-search {
+    margin: 0;
+  }
+  .homepage .module-search .module-content .heading {
+    font-size: 16px;
+  }
+  .search-form .search-input.search-giant input {
+    padding: 5px;
+  }
+  .homepage .media-grid {
+    margin: 1em 0 0;
+  }
+  .homepage .media-item {
+    flex: 1 0 calc(50% - 10px);
+  }
+  .media-heading {
+    font-size: 14px;
+    margin: 0 -15px;
+  }
+  /* Search */
+  .toolbar .breadcrumb a {
+    color: black;
+    font-size: 16px;
+  }
+  .module-content {
+    padding: 0;
+  }
+  #field-giant-search {
+    padding: 5px 8px;
+    height: 36px;
+    font-size: 16px;
+  }
+  #field-giant-search ~ .input-group-btn  .btn {
+    padding: 5px 8px;
+  }
+  #dataset-map {
+    display: none;
+  }
+  /* Dataset */
+  .dataset-item-content.image {
+    max-height: 100px;
+    display: block;
+  }
+  .dataset-item-content.text {
+    width: 100%;
+  }
+  .dataset-item-content .dataset-heading {
+    width: calc(100% - 32px);
+    position: absolute;
+    top: 0;
+  }
+  .context-info .image img {
+    max-height: 200px;
+    height: auto;
+    max-width: 100%;
+    width: auto;
+  }
+  .primary .module-content > h1 {
+    display: none;
+  }
+  .social {
+    display: none;
+  }
+  .additional-info thead {
+    display: none;
+  }
+  .additional-info th,
+  .additional-info td {
+    display: block;
+    width: 100%;
+  }
+  .select2-container {
+    max-width: 100%;
+  }
+}

--- a/ckanext/theme/fanstatic/theme.css
+++ b/ckanext/theme/fanstatic/theme.css
@@ -21,24 +21,8 @@ header nav {
   width: 100%;
 }
 
-.dataset-heading {
-    border-bottom: dotted 1px #ddd;
-    padding-bottom: 8px;
-    font-size: 15px;
-}
-
 .dataset-list {
     clear: right;
-}
-
-.dataset-item {
-    border-bottom: none;
-    border-left: 2px solid #0072bc;
-    padding: 10px 10px !important;
-    margin-bottom: 35px;
-    border-radius: 3px;
-    background: #f9f9f9;
-    position: relative;
 }
 
 .dataset-item-content {
@@ -46,12 +30,6 @@ header nav {
     vertical-align: top;
 }
 
-.dataset-item-content .dataset-heading {
-    text-overflow:ellipsis;
-    overflow-x:hidden;
-    white-space:nowrap;
-    width: calc(100% - 50px);
-}
 
 .dataset-item-content.text {
     width: calc(100% - 145px);
@@ -400,7 +378,6 @@ fieldset.checkboxes label input[type=checkbox] {
 }
 
 .media-grid {
-    height: auto !important;
     justify-content: center;
     padding-top: 0;
 }

--- a/ckanext/theme/fanstatic/theme.css
+++ b/ckanext/theme/fanstatic/theme.css
@@ -413,3 +413,29 @@ fieldset.checkboxes label input[type=checkbox] {
     font-weight: bold;
     color: #9f0017;
 }
+
+footer {
+  text-align: center;
+}
+
+@media (max-width: 768px) {
+  h2 {
+    font-size: 16px;
+  }
+  .show-filters {
+    position: absolute;
+    right: 0;
+    margin-top: -3.25em;
+  }
+  .header-home {
+    display: none;
+  }
+  .container .toolbar .breadcrumb a {
+    font-size: 14px;
+  }
+  #field-order-by {
+    padding: 0 3px;
+    height: 25px;
+    font-size: 13px;
+  }
+}

--- a/ckanext/theme/fanstatic/theme.css
+++ b/ckanext/theme/fanstatic/theme.css
@@ -2,6 +2,11 @@ h2 {
     font-size: 21px;
 }
 
+header nav {
+  position: static;
+  z-index: auto;
+}
+
 .wrapper {
     background: none;
     border: 0;
@@ -361,7 +366,6 @@ fieldset.checkboxes label input[type=checkbox] {
     background-color: transparent;
     -webkit-transform: none;
     transform: none;
-    z-index: 1;
     border: 0;
     margin: 0;
 }

--- a/ckanext/theme/templates/base.html
+++ b/ckanext/theme/templates/base.html
@@ -5,6 +5,7 @@
   {% resource 'theme/font.css' %}
   {% resource 'theme/main.css' %}
   {% resource 'theme/styles.css' %}
+  {% resource 'theme/base_theme.css' %}
   {% resource 'theme/theme.css' %}
   {% resource 'theme/resources.css' %}
 {% endblock %}

--- a/ckanext/theme/templates/snippets/search_form.html
+++ b/ckanext/theme/templates/snippets/search_form.html
@@ -1,0 +1,26 @@
+{% ckan_extends %}
+
+  {% block search_facets %}
+    {% if facets %}
+      <p class="filter-list">
+        {% for field in facets.fields %}
+          {% set search_facets_items = facets.search.get(field)['items'] %}
+          <span class="facet">{{ facets.titles.get(field) }}:</span>
+          {% for value in facets.fields[field] %}
+            <span class="filtered pill">
+              {%- if facets.translated_fields and facets.translated_fields.has_key((field,value)) -%}
+                {{ facets.translated_fields[(field,value)] }}
+              {%- else -%}
+                {{ h.list_dict_filter(search_facets_items, 'name', 'display_name', value) }}
+              {%- endif %}
+              <a href="{{ facets.remove_field(field, value) }}" class="remove" title="{{ _('Remove') }}"><i class="fa fa-times"></i></a>
+            </span>
+          {% endfor %}
+        {% endfor %}
+      </p>
+      <a class="show-filters btn btn-default">
+        <span class="hidden-xs">{{ _('Filter Results') }}</span>
+        <span class="visible-xs-inline">{{ _('Filtrer') }}</span>
+      </a>
+    {% endif %}
+  {% endblock %}


### PR DESCRIPTION
`base_theme.css` can be shared with hdf.
Ideally we would only allow «colors» modification in specific theme, & share structure styles accross customers.