### PR TITLE
bug-proof the harvesting process

### DIFF
--- a/ckanext/theme/plugin.py
+++ b/ckanext/theme/plugin.py
@@ -129,7 +129,10 @@ class ThemePlugin(plugins.SingletonPlugin):
         log.info('Working on dataset {}'.format(package_dict['name']))
         # fix harvested package to make it compatible with the scheming extension
         # & transform geonetwork metadata to make them available in the schema
-        harvest_helpers.fix_harvest_scheme_fields(package_dict, data_dict)
+        try:
+            harvest_helpers.fix_harvest_scheme_fields(package_dict, data_dict)
+        except Exception as e:
+            log.error('Error during improved harvesting of dataset {}. Raised exception {}'.format(package_dict['name'], e))
         return package_dict
 
     # ITemplateHelper


### PR DESCRIPTION
according to https://github.com/ckan/ckanext-harvest/README.rst,
'Occasionally you can find a harvesting job is in a "limbo state"...'
if an error is raised during harvesting, if my block the whole
harvesting process and it won't be able to get back to proper work.
This should prevent all error to hang the global harvest process