### PR TITLE
Don't hardcode list of themes & path

### DIFF
--- a/ckanext/theme/template_helpers.py
+++ b/ckanext/theme/template_helpers.py
@@ -68,6 +68,22 @@ def thematics_list(field):
         return list()
 
 
+def thematics():
+    """
+        :return: List of all thematics (groups)
+        """
+    # create a list of value/label entries to be used in the multiselect field in the dataset form
+    try:
+
+        user = toolkit.get_action('get_site_user')({'ignore_auth': True}, {})
+        context = {'user': user['name']}
+        groups = toolkit.get_action('group_list')(context, {'all_fields': True })
+        return groups
+    except:
+        print("Error retrieving groups list")
+        return list()
+
+
 def get_helpers():
     '''Register the functions above as a template helper functions.
 
@@ -79,5 +95,6 @@ def get_helpers():
         'theme_dict_list_or_dict_reduce': dict_list_or_dict_reduce,
         'theme_list_data_formats': list_data_formats,
         'theme_update_frequency_etalab_codelist' : update_frequency_etalab_codelist,
-        'theme_thematics_list' : thematics_list
+        'theme_thematics_list' : thematics_list,
+        'theme_thematics' : thematics
     }

--- a/ckanext/theme/templates/home/layout3.html
+++ b/ckanext/theme/templates/home/layout3.html
@@ -3,151 +3,23 @@
     {% block search %} {% snippet 'home/snippets/search.html' %} {% endblock %}
     <div class="home-grid"></div>
     <ul class="media-grid">
+      {% for thm in h.theme_thematics() %}
       <li class="media-item">
         <img
-          src="{{root_path|default('/ckan')}}/geo2france/groups/amenagement.png"
-          alt="amenagement"
+          src="{{ thm.image_display_url }}"
+          alt="{{ thm.name }}"
           class="media-image img-responsive"
         />
-        <h3 class="media-heading">Aménagement</h3>
+        <h3 class="media-heading">{{ thm.display_name }}</h3>
         <a
-          href="{{root_path|default('/ckan')}}/dataset?groups=amenagement"
-          title="Afficher Aménagement"
+          href="{{ h.url_for('/dataset?groups=' + thm.name.encode('utf8')) }}"
+          title="Afficher {{ thm.display_name }}"
           class="media-view"
         >
-          <span>Afficher Aménagement</span>
+          <span>Afficher {{ thm.display_name }}</span>
         </a>
       </li>
-
-      <li class="media-item">
-        <img
-          src="{{root_path|default('/ckan')}}/geo2france/groups/limites-administratives.png"
-          alt="donnees-reference"
-          class="media-image img-responsive"
-        />
-        <h3 class="media-heading">Données de référence</h3>
-        <a
-          href="{{root_path|default('/ckan')}}/dataset?groups=donnees-reference"
-          title="Afficher Données de référence"
-          class="media-view"
-        >
-          <span>Afficher Données de référence</span>
-        </a>
-      </li>
-
-      <li class="media-item">
-        <img
-          src="{{root_path|default('/ckan')}}/geo2france/groups/economie.png"
-          alt="economie-emploi"
-          class="media-image img-responsive"
-        />
-        <h3 class="media-heading">Économie et emploi</h3>
-        <a
-          href="{{root_path|default('/ckan')}}/dataset?groups=economie-emploi"
-          title="Afficher Économie et emploi"
-          class="media-view"
-        >
-          <span>Afficher Économie et emploi</span>
-        </a>
-      </li>
-
-      <li class="media-item">
-        <img
-          src="{{root_path|default('/ckan')}}/geo2france/groups/formation.png"
-          alt="education-formation"
-          class="media-image img-responsive"
-        />
-        <h3 class="media-heading">Education et formation</h3>
-        <a
-          href="{{root_path|default('/ckan')}}/dataset?groups=education-formation"
-          title="Afficher Education et formation"
-          class="media-view"
-        >
-          <span>Afficher Education et formation</span>
-        </a>
-      </li>
-
-      <li class="media-item">
-        <img
-          src="{{root_path|default('/ckan')}}/geo2france/groups/environnement.png"
-          alt="environnement-risques-sante"
-          class="media-image img-responsive"
-        />
-        <h3 class="media-heading">Environnement, risques et santé</h3>
-        <a
-          href="{{root_path|default('/ckan')}}/dataset?groups=environnement-risques-sante"
-          title="Afficher Environnement, risques et santé"
-          class="media-view"
-        >
-          <span>Afficher Environnement, risques et santé</span>
-        </a>
-      </li>
-
-      <li class="media-item">
-        <img
-          src="{{root_path|default('/ckan')}}/geo2france/groups/administration.png"
-          alt="institutions-partenariats"
-          class="media-image img-responsive"
-        />
-        <h3 class="media-heading">Institutions et partenariats</h3>
-        <a
-          href="{{root_path|default('/ckan')}}/dataset?groups=institutions-partenariats"
-          title="Afficher Institutions et partenariats"
-          class="media-view"
-        >
-          <span>Afficher Institutions et partenariats</span>
-        </a>
-      </li>
-
-      <li class="clearfix js-hide"></li>
-
-      <li class="media-item">
-        <img
-          src="{{root_path|default('/ckan')}}/geo2france/groups/energie.png"
-          alt="reseaux-energies"
-          class="media-image img-responsive"
-        />
-        <h3 class="media-heading">Réseaux et énergies</h3>
-        <a
-          href="{{root_path|default('/ckan')}}/dataset?groups=reseaux-energies"
-          title="Afficher Réseaux et énergies"
-          class="media-view"
-        >
-          <span>Afficher Réseaux et énergies</span>
-        </a>
-      </li>
-
-      <li class="media-item">
-        <img
-          src="{{root_path|default('/ckan')}}/geo2france/groups/mobilite.png"
-          alt="transports-mobilites"
-          class="media-image img-responsive"
-        />
-        <h3 class="media-heading">Transports et mobilités</h3>
-        <a
-          href="{{root_path|default('/ckan')}}/dataset?groups=transports-mobilites"
-          title="Afficher Transports et mobilités"
-          class="media-view"
-        >
-          <span>Afficher Transports et mobilités</span>
-        </a>
-      </li>
-
-      <li class="media-item">
-        <img
-          src="{{root_path|default('/ckan')}}/geo2france/groups/culture.png"
-          alt="culture"
-          class="media-image img-responsive"
-        />
-        <h3 class="media-heading">Vie sociale et culturelle</h3>
-        <a
-          href="{{root_path|default('/ckan')}}/dataset?groups=culture"
-          title="Afficher Vie sociale et culturelle"
-          class="media-view"
-        >
-          <span>Afficher Vie sociale et culturelle</span>
-        </a>
-      </li>
+      {% endfor %}
       <li class="clearfix js-hide"></li>
     </ul>
   </div>


### PR DESCRIPTION
ckan helpers allow for a much more lean template. It will be more resilient, since we use the groups'  attributes for the links & images.
It also seems to be faster : previous version went through auth 18 times to load. New version, just 2 times.

It will work better with i18n if necessary, since url_for take the selected language into account